### PR TITLE
Merge presentation changes into develop

### DIFF
--- a/app/generator_gui.py
+++ b/app/generator_gui.py
@@ -1,6 +1,6 @@
 '''
     File: generator_gui.py
-    Date: 04/01/2026
+    Date: 04/03/2026
     Author: Tyler Strohl, Kyle Smith, & Chayse Altland
     Class: CMSC 420
     Description: Schedule Generator dialogs and helpers for the GUI.
@@ -14,13 +14,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtWidgets import (
-    QFileDialog,
-    QInputDialog,
-    QMessageBox,
-    QWidget,
-    QProgressDialog,
-    QApplication,
-    QProgressBar,
+
+    QFileDialog, QInputDialog, QMessageBox, QWidget,
+    QProgressDialog, QApplication, QProgressBar, QDialog,
+    QVBoxLayout, QCheckBox, QDialogButtonBox
 )
 print("DEBUG: loaded app/generator_gui.py from schedule-config-editor")
 #the work-around for scheduler function blocking main GUI thread.
@@ -145,7 +142,7 @@ class GenConfigManager:
 
     #enables/disables the optimization flags in the config file.
     def set_optimize(self, parent: QWidget) -> None:
-        
+        """Opens a checklist dialog to toggle specific optimizer flags."""
         if not self._ensure_config_loaded(parent):
             return
         
@@ -155,24 +152,41 @@ class GenConfigManager:
         ]
 
         current_flags = self._config_data.get("optimizer_flags", [])
-        is_currently_on = len(current_flags) > 0
-        start_index = 0 if is_currently_on else 1
 
-        text, ok = QInputDialog.getItem(
-            parent, "Specify Optimization", "Enable/Disable All:", 
-            ["True", "False"], start_index, False
-        )
+        # --- Build Custom Dialog ---
+        dialog = QDialog(parent)
+        dialog.setWindowTitle("Optimizer Configuration")
+        dialog.setMinimumWidth(300)
+        
+        layout = QVBoxLayout(dialog)
+        
+        # Create a checkbox for each flag
+        checkbox_widgets = []
+        for flag in full_flags:
+            cb = QCheckBox(flag.replace("_", " ").title()) # e.g. "faculty_course" -> "Faculty Course"
+            if flag in current_flags:
+                cb.setChecked(True)
+            layout.addWidget(cb)
+            checkbox_widgets.append((flag, cb))
 
-        if ok:
-            if text == "True":
-                self._config_data["optimizer_flags"] = full_flags
-            else:
-                self._config_data["optimizer_flags"] = []
+        # Add Standard OK/Cancel Buttons
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box.accepted.connect(dialog.accept)
+        button_box.rejected.connect(dialog.reject)
+        layout.addWidget(button_box)
 
+        # --- Execute and Save ---
+        if dialog.exec():
+            # Rebuild the list based on what is checked
+            new_flags = [flag for flag, cb in checkbox_widgets if cb.isChecked()]
+            self._config_data["optimizer_flags"] = new_flags
+
+            # Save logic
             config_mgr = getattr(parent, "config_mgr", None)
             if config_mgr:
                 config_mgr.data = self._config_data
                 config_mgr.save(parent)
+                QMessageBox.information(parent, "Updated", f"Active optimizations:\n{', '.join(new_flags) if new_flags else 'None'}")
             else:
                 self._save(parent)
 
@@ -245,6 +259,10 @@ class GenConfigManager:
 
 
             clean_data = json.loads(json.dumps(self._config_data))
+            
+            optimizer_flags = clean_data.get("optimizer_flags", [])
+            clean_data["optimizer_flags"] = optimizer_flags
+            
             cfg = clean_data.setdefault("config", {})
 
             ui_slots = cfg.pop("time_slots", {})

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -121,7 +121,7 @@ class MainWindow(QMainWindow):
         #Splitter organizes our panels.
         self.splitter = QSplitter(Qt.Orientation.Horizontal)
         
-        self.cfg_panel = ContentPanel("Schedule Preview", "#000000")
+        self.cfg_panel = ContentPanel("NO FILE IMPORTED", "#000000")
         self.cfg_panel.layout.setContentsMargins(0, 0, 0, 0)
         self.cfg_panel.layout.setSpacing(0)
 
@@ -436,7 +436,8 @@ class MainWindow(QMainWindow):
 
             self.schedules = imported_data
             self.current_schedule_index = 0
-            #TODO: If importing a schedule, show user the file name
+            #Updates filepath displayed for imported schedules
+            self.cfg_panel.update_title(self.cfg_panel, self.config_mgr.import_file)
             self.update_schedule_display()
 
             try:
@@ -479,7 +480,9 @@ class MainWindow(QMainWindow):
             try:
                 self.clear_clicked = True
                 self.schedules.clear()
-                #make sure to also update the imported schedule panel
+                #Updates imported schedules label
+                self.cfg_panel.update_title(self.cfg_panel)
+                self.import_file = ""
                 self.update_schedule_display()
                 QMessageBox.information(self, "Success", "Schedule/s have been cleared.")
             except:
@@ -504,7 +507,7 @@ class MainWindow(QMainWindow):
         nav_layout.addWidget(next_btn)
         layout.addLayout(nav_layout)
 
-    #TODO: Move more of this code to config_mgr?
+    #TODO: Move more of this code to config_mgr with design patterns.
     def _refresh_schedule_display(self):
         """Updates the viewer text based on the current schedule index."""
         if not self.schedules: return
@@ -522,18 +525,6 @@ class MainWindow(QMainWindow):
         """Decrements schedule index with wrap-around."""
         if self.schedules:
             self.current_schedule_index = (self.current_schedule_index - 1) % len(self.schedules)
-
-    #TODO: Filters do not always work properly. Fix.
-    # - When importing schedule and not changing default config,
-    #   the filters do not work properly,
-    #   because they are going off of what config is currently loaded,
-    #   and not what schedule is currently loaded.
-
-    #TODO: Change import/export to JSON
-
-    #for filters:
-    #if schedules are generated, read from CONFIG JSON FILE
-    #if schedules are imported, read from IMPORTED JSON FILE
 
     def update_schedule_display(self, group_by: str = "all"):
         """
@@ -573,8 +564,7 @@ class MainWindow(QMainWindow):
                 else:
                     return
 
-        #TODO: If importing a schedule, show user the file name
-        self.cfg_panel.update_title(self.cfg_panel, self.config_mgr.filepath)
+        #Updated filepath displayed for active config
         self.cfg_panel.update_title(self.path_label, self.config_mgr.filepath)
         #Show schedules through appropriate filter (all, faculty, room, lab)
         filter_suffix = f" | FILTER: {filter_val}" if filter_val else ""

--- a/app/menu_widgets.py
+++ b/app/menu_widgets.py
@@ -31,20 +31,11 @@ class ContentPanel(QFrame):
         super().__init__(parent)
         self.layout = QVBoxLayout(self)
 
-        # Set alignment to Top to prevent vertical centering
         self.layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-
         self.label = QLabel(title)
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        #What is this?
-        #====================================
         self.layout.addWidget(self.label)
-        if stretch_middle:
-            self.layout.addStretch()
-        # Add a stretch factor to push everything above it to the top
         self.layout.addStretch()
-        #====================================
 
         self.setFrameShape(QFrame.Shape.StyledPanel)
         self._base_color = color
@@ -89,12 +80,17 @@ class ContentPanel(QFrame):
             f"border: none; color: {text_color};"
         )
 
-    def update_title(self, label, file_path):
+    def update_title(self, label, file_path = None):
         """
         Updates the file_path label using the basename of current file_path.
 
         :param file_path: The full path to the active configuration file.
         """
+        #Fall into here when clearing imported schedules
+        if file_path == None:
+            self.label.setText("NO FILE IMPORTED")
+            return
+
         display_text = os.path.basename(file_path)
         #Change which schedule filepath is displayed
         if (isinstance(label, ContentPanel)):

--- a/config/example.json
+++ b/config/example.json
@@ -1,9 +1,9 @@
 {
     "config": {
         "rooms": [
+            "Roddy 136",
             "Roddy 140",
-            "Roddy 147",
-            "Roddy 136"
+            "Roddy 147"
         ],
         "labs": [
             "Linux",
@@ -611,150 +611,63 @@
                     "Linux": 1
                 }
             }
-        ],
-        "time_slots": {
-            "Monday": {
-                "enabled": true,
-                "blocks": [
-                    {
-                        "start_time": "08:00",
-                        "end_time": "17:00",
-                        "spacing_minutes": 60,
-                        "slots": [
-                            "08:00",
-                            "09:00",
-                            "10:00",
-                            "11:00",
-                            "12:00",
-                            "13:00",
-                            "14:00",
-                            "15:00",
-                            "16:00"
-                        ]
-                    }
-                ]
-            },
-            "Tuesday": {
-                "enabled": true,
-                "blocks": [
-                    {
-                        "start_time": "08:00",
-                        "end_time": "17:00",
-                        "spacing_minutes": 60,
-                        "slots": [
-                            "08:00",
-                            "09:00",
-                            "10:00",
-                            "11:00",
-                            "12:00",
-                            "13:00",
-                            "14:00",
-                            "15:00",
-                            "16:00"
-                        ]
-                    }
-                ]
-            },
-            "Wednesday": {
-                "enabled": true,
-                "blocks": [
-                    {
-                        "start_time": "08:00",
-                        "end_time": "17:00",
-                        "spacing_minutes": 60,
-                        "slots": [
-                            "08:00",
-                            "09:00",
-                            "10:00",
-                            "11:00",
-                            "12:00",
-                            "13:00",
-                            "14:00",
-                            "15:00",
-                            "16:00"
-                        ]
-                    }
-                ]
-            },
-            "Thursday": {
-                "enabled": true,
-                "blocks": [
-                    {
-                        "start_time": "08:00",
-                        "end_time": "17:00",
-                        "spacing_minutes": 60,
-                        "slots": [
-                            "08:00",
-                            "09:00",
-                            "10:00",
-                            "11:00",
-                            "12:00",
-                            "13:00",
-                            "14:00",
-                            "15:00",
-                            "16:00"
-                        ]
-                    }
-                ]
-            },
-            "Friday": {
-                "enabled": true,
-                "blocks": [
-                    {
-                        "start_time": "08:00",
-                        "end_time": "17:00",
-                        "spacing_minutes": 60,
-                        "slots": [
-                            "08:00",
-                            "09:00",
-                            "10:00",
-                            "11:00",
-                            "12:00",
-                            "13:00",
-                            "14:00",
-                            "15:00",
-                            "16:00"
-                        ]
-                    }
-                ]
-            }
-        }
+        ]
     },
     "time_slot_config": {
         "times": {
             "MON": [
                 {
                     "start": "08:00",
-                    "end": "17:00",
-                    "spacing": 60
+                    "spacing": 60,
+                    "end": "19:00"
                 }
             ],
             "TUE": [
                 {
                     "start": "08:00",
-                    "end": "17:00",
-                    "spacing": 60
+                    "spacing": 60,
+                    "end": "12:00"
+                },
+                {
+                    "start": "13:10",
+                    "spacing": 60,
+                    "end": "17:10"
+                },
+                {
+                    "start": "17:10",
+                    "spacing": 30,
+                    "end": "19:40"
                 }
             ],
             "WED": [
                 {
                     "start": "08:00",
-                    "end": "17:00",
-                    "spacing": 60
+                    "spacing": 60,
+                    "end": "19:00"
                 }
             ],
             "THU": [
                 {
                     "start": "08:00",
-                    "end": "17:00",
-                    "spacing": 60
+                    "spacing": 60,
+                    "end": "12:00"
+                },
+                {
+                    "start": "13:10",
+                    "spacing": 60,
+                    "end": "17:10"
+                },
+                {
+                    "start": "17:10",
+                    "spacing": 30,
+                    "end": "19:40"
                 }
             ],
             "FRI": [
                 {
                     "start": "08:00",
-                    "end": "17:00",
-                    "spacing": 60
+                    "spacing": 60,
+                    "end": "17:00"
                 }
             ]
         },
@@ -900,6 +813,120 @@
                         "duration": 50
                     }
                 ]
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 110,
+                        "lab": true
+                    },
+                    {
+                        "day": "TUE",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 50
+                    }
+                ],
+                "disabled": true
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 110,
+                        "lab": true
+                    },
+                    {
+                        "day": "WED",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 50
+                    }
+                ],
+                "disabled": true
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 110,
+                        "lab": true
+                    },
+                    {
+                        "day": "THU",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 50
+                    }
+                ],
+                "disabled": true
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 50
+                    },
+                    {
+                        "day": "TUE",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 110,
+                        "lab": true
+                    }
+                ],
+                "disabled": true
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 50
+                    },
+                    {
+                        "day": "WED",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 110,
+                        "lab": true
+                    }
+                ],
+                "disabled": true
+            },
+            {
+                "credits": 4,
+                "meetings": [
+                    {
+                        "day": "MON",
+                        "duration": 50
+                    },
+                    {
+                        "day": "THU",
+                        "duration": 50
+                    },
+                    {
+                        "day": "FRI",
+                        "duration": 110,
+                        "lab": true
+                    }
+                ],
+                "disabled": true
             }
         ]
     },


### PR DESCRIPTION
Here is what was changed in this PR:

- Imported schedules filepath now displays.
- Optimization flags can now be manually selected, rather than enabling/disabling all of them.
- Attempted to fix bug with view filters when importing schedules. Unfortunately was not fixed, but import/export format was successfully changed from CSV to JSON.

This is the last of the presentation changes for Sprint 3.